### PR TITLE
Ajustes classe css col-4 para mobile

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -111,4 +111,7 @@ table tr:first-child th {
     .base-container {
         margin-top: 15px;
     }
+    .col-4 {
+        width: 100%;
+    }
 }

--- a/resources/vue/view/configurations/ConfigurationsView.vue
+++ b/resources/vue/view/configurations/ConfigurationsView.vue
@@ -4,7 +4,7 @@
         <loading-component v-show="loadingDone === 0"/>
         <div v-show="loadingDone === 1">
             <div class="nav mt-2 justify-content-end">
-                <mfp-title :title="'Configurações do usuário'"/>
+                <mfp-title :title="'Configurações'"/>
             </div>
             <divider/>
             <input-money :value="user.salary" :title="'Salário Bruto'" @input-money="user.salary = $event"/>


### PR DESCRIPTION
Adicionado CSS para definir que os inputs col-4 no mobile vão ocupar 100% da linha horizontal.