### PR TITLE
fix(planejamento mercado): valor negativo ao gastar mais que o planejado

### DIFF
--- a/app/Services/Tools/MarketPlannerService.php
+++ b/app/Services/Tools/MarketPlannerService.php
@@ -69,6 +69,17 @@ class MarketPlannerService
 
     public function getFirstInstallmentMarket(): float
     {
-        return round($this->marketPlannerValue - $this->thisMonthMarketSpentValue, 2);
+        $firstMonthValue = round($this->getMarketPlannerValue() - $this->getThisMonthMarketSpentValue(), 2);
+        return max($firstMonthValue, 0);
+    }
+
+    protected function getMarketPlannerValue(): float
+    {
+        return $this->marketPlannerValue;
+    }
+
+    protected function getThisMonthMarketSpentValue(): float
+    {
+        return $this->thisMonthMarketSpentValue;
     }
 }

--- a/tests/Unit/Service/Tools/MarketPlannerServiceUnitTest.php
+++ b/tests/Unit/Service/Tools/MarketPlannerServiceUnitTest.php
@@ -160,4 +160,32 @@ class MarketPlannerServiceUnitTest extends Falcon9
         $this->assertEquals(InvoiceEnum::FIXED_INSTALLMENTS, $invoice->getInstallments());
         $this->assertNull($invoice->getCountName());
     }
+
+    /**
+     * Parâmetros do teste:
+     * - Valor positivo
+     */
+    public function testGetFirstInstallmentMarketTestOne()
+    {
+        $marketPlannerMock = Mockery::mock(MarketPlannerService::class)->makePartial();
+        $marketPlannerMock->shouldAllowMockingProtectedMethods();
+        $marketPlannerMock->shouldReceive('getThisMonthMarketSpentValue')->once()->andReturn(50);
+        $marketPlannerMock->shouldReceive('getMarketPlannerValue')->once()->andReturn(100);
+
+        $this->assertEquals(50, $marketPlannerMock->getFirstInstallmentMarket());
+    }
+
+    /**
+     * Parâmetros do teste:
+     * - Valor negativo
+     */
+    public function testGetFirstInstallmentMarketTwo()
+    {
+        $marketPlannerMock = Mockery::mock(MarketPlannerService::class)->makePartial();
+        $marketPlannerMock->shouldAllowMockingProtectedMethods();
+        $marketPlannerMock->shouldReceive('getThisMonthMarketSpentValue')->once()->andReturn(150);
+        $marketPlannerMock->shouldReceive('getMarketPlannerValue')->once()->andReturn(100);
+
+        $this->assertEquals(0, $marketPlannerMock->getFirstInstallmentMarket());
+    }
 }


### PR DESCRIPTION
Corrigido bug onde quando foi gasto um valor maior que o planejado para o mercado, o valor restante de planejamento ficava negativo.