### PR TITLE
refactor: tratando exceptions no handler

### DIFF
--- a/app/Exceptions/ConstraintException.php
+++ b/app/Exceptions/ConstraintException.php
@@ -2,12 +2,8 @@
 
 namespace App\Exceptions;
 
-use RuntimeException;
+use App\Exceptions\ResponseExceptions\BadRequestException;
 
-class ConstraintException extends RuntimeException
+class ConstraintException extends BadRequestException
 {
-    public function __construct(string $message)
-    {
-        parent::__construct($message);
-    }
 }

--- a/app/Exceptions/ResponseExceptions/BadRequestException.php
+++ b/app/Exceptions/ResponseExceptions/BadRequestException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions\ResponseExceptions;
+
+use Exception;
+
+class BadRequestException extends Exception
+{
+}

--- a/app/Exceptions/ValueException.php
+++ b/app/Exceptions/ValueException.php
@@ -2,8 +2,8 @@
 
 namespace App\Exceptions;
 
-use RuntimeException;
+use App\Exceptions\ResponseExceptions\BadRequestException;
 
-class ValueException extends RuntimeException
+class ValueException extends BadRequestException
 {
 }

--- a/app/Http/Controllers/CreditCardController.php
+++ b/app/Http/Controllers/CreditCardController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Exceptions\ConstraintException;
-use App\Http\Response\ResponseError;
 use App\Resources\CreditCard\CreditCardResource;
 use App\Services\CreditCard\CreditCardService;
 use Illuminate\Http\JsonResponse;
@@ -53,11 +51,7 @@ class CreditCardController extends BasicController
 
     public function delete(int $id): Response|JsonResponse
     {
-        try {
-            $this->getService()->deleteById($id);
-            return response(null, ResponseAlias::HTTP_OK);
-        } catch (ConstraintException $exception) {
-            return ResponseError::responseError($exception->getMessage(), Response::HTTP_BAD_REQUEST);
-        }
+        $this->getService()->deleteById($id);
+        return response(null, ResponseAlias::HTTP_OK);
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,11 +8,8 @@ use Symfony\Component\HttpFoundation\Response as ResponseAlias;
 
 class DashboardController
 {
-    protected DashboardService $service;
-
-    public function __construct(DashboardService $service)
+    public function __construct(protected DashboardService $service)
     {
-        $this->service = $service;
     }
 
     public function index(): JsonResponse

--- a/app/Http/Controllers/Investment/InvestmentController.php
+++ b/app/Http/Controllers/Investment/InvestmentController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Investment;
 
-use App\Exceptions\ValueException;
 use App\Http\Controllers\BasicController;
 use App\Http\Response\ResponseError;
 use App\Resources\Investment\InvestmentResource;
@@ -72,15 +71,11 @@ class InvestmentController extends BasicController
 
     public function rescueApportInvestment(Request $request): JsonResponse
     {
-        try {
-            $invalid = $this->getService()->isInvalidRequest($request, $this->rulesRescueApport());
-            if ($invalid instanceof MessageBag) {
-                return ResponseError::responseError($invalid, ResponseAlias::HTTP_BAD_REQUEST);
-            }
-            $this->getService()->rescueApportInvestment($request->all());
-            return response()->json(null, ResponseAlias::HTTP_OK);
-        } catch (ValueException $e) {
-            return ResponseError::responseError($e->getMessage(), ResponseAlias::HTTP_BAD_REQUEST);
+        $invalid = $this->getService()->isInvalidRequest($request, $this->rulesRescueApport());
+        if ($invalid instanceof MessageBag) {
+            return ResponseError::responseError($invalid, ResponseAlias::HTTP_BAD_REQUEST);
         }
+        $this->getService()->rescueApportInvestment($request->all());
+        return response()->json(null, ResponseAlias::HTTP_OK);
     }
 }

--- a/app/Http/Controllers/MovementController.php
+++ b/app/Http/Controllers/MovementController.php
@@ -8,7 +8,6 @@ use App\Resources\Movement\MovementResource;
 use App\Services\Movement\MovementService;
 use App\Tools\Request\RequestTools;
 use App\VO\Movement\MovementVO;
-use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\MessageBag;
@@ -77,29 +76,21 @@ class MovementController extends BasicController
 
     public function insertTransfer(Request $request): JsonResponse
     {
-        try {
-            $invalid = $this->getService()->isInvalidRequest($request, $this->rulesInsertTransfer());
-            if ($invalid instanceof MessageBag) {
-                return ResponseError::responseError($invalid, ResponseAlias::HTTP_BAD_REQUEST);
-            }
-            $data = $request->json()->all();
-            $transferSpent = $this->getResource()->makeTransferSpentMovement($data);
-            $this->getService()->insertWithWalletUpdateType($transferSpent, MovementEnum::SPENT);
-            $transferReceived = $this->getResource()->makeTransferGainMovement($data);
-            $this->getService()->insertWithWalletUpdateType($transferReceived, MovementEnum::GAIN);
-            return response()->json(null, ResponseAlias::HTTP_CREATED);
-        } catch (QueryException $exception) {
-            return $this->returnErrorDatabaseConnect($exception);
+        $invalid = $this->getService()->isInvalidRequest($request, $this->rulesInsertTransfer());
+        if ($invalid instanceof MessageBag) {
+            return ResponseError::responseError($invalid, ResponseAlias::HTTP_BAD_REQUEST);
         }
+        $data = $request->json()->all();
+        $transferSpent = $this->getResource()->makeTransferSpentMovement($data);
+        $this->getService()->insertWithWalletUpdateType($transferSpent, MovementEnum::SPENT);
+        $transferReceived = $this->getResource()->makeTransferGainMovement($data);
+        $this->getService()->insertWithWalletUpdateType($transferReceived, MovementEnum::GAIN);
+        return response()->json(null, ResponseAlias::HTTP_CREATED);
     }
 
     public function deleteTransfer(int $id): JsonResponse
     {
-        try {
-            $this->getService()->deleteTransferById($id);
-            return response()->json(null, ResponseAlias::HTTP_OK);
-        } catch (QueryException $exception) {
-            return $this->returnErrorDatabaseConnect($exception);
-        }
+        $this->getService()->deleteTransferById($id);
+        return response()->json(null, ResponseAlias::HTTP_OK);
     }
 }

--- a/app/Http/Controllers/WalletController.php
+++ b/app/Http/Controllers/WalletController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Exceptions\ConstraintException;
-use App\Http\Response\ResponseError;
 use App\Resources\WalletResource;
 use App\Services\WalletService;
 use App\VO\WalletVO;
@@ -55,11 +53,7 @@ class WalletController extends BasicController
 
     public function delete(int $id): Response|JsonResponse
     {
-        try {
-            $this->getService()->deleteById($id);
-            return response(null, ResponseAlias::HTTP_OK);
-        } catch (ConstraintException $exception) {
-            return ResponseError::responseError($exception->getMessage(), Response::HTTP_BAD_REQUEST);
-        }
+        $this->getService()->deleteById($id);
+        return response(null, ResponseAlias::HTTP_OK);
     }
 }

--- a/tests/backend/Unit/Http/Controllers/MovementControllerUnitTest.php
+++ b/tests/backend/Unit/Http/Controllers/MovementControllerUnitTest.php
@@ -7,8 +7,6 @@ use App\Enums\MovementEnum;
 use App\Http\Controllers\MovementController;
 use App\Resources\Movement\MovementResource;
 use App\Services\Movement\MovementService;
-use Exception;
-use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Support\MessageBag;
 use Mockery;
@@ -116,40 +114,6 @@ class MovementControllerUnitTest extends Falcon9
         $response = $controllerMock->deleteTransfer(1);
 
         $this->assertEquals(200, $response->getStatusCode());
-    }
-
-    public function testDeleteTransferQueryException()
-    {
-        $serviceMock = Mockery::mock(MovementService::class);
-        $serviceMock->shouldReceive('deleteTransferById')->once()->andThrowExceptions(
-            [new QueryException('test', "SELECT ....", [], new Exception())]
-        );
-
-        $controllerMock = Mockery::mock(MovementController::class, [$serviceMock])->makePartial();
-        $controllerMock->shouldAllowMockingProtectedMethods();
-
-        $response = $controllerMock->deleteTransfer(1);
-
-        $this->assertEquals(500, $response->getStatusCode());
-        $this->assertEquals('Erro ao se conectar com o banco de dados!', $response->getData()->message);
-    }
-
-    public function testInsertTransferQueryException()
-    {
-        $serviceMock = Mockery::mock(MovementService::class);
-        $serviceMock->shouldReceive('isInvalidRequest')->once()->andReturnFalse();
-        $serviceMock->shouldReceive('insertWithWalletUpdateType')->once()->andThrowExceptions(
-            [new QueryException('test', "SELECT ....", [], new Exception())]
-        );
-
-        $controllerMock = Mockery::mock(MovementController::class, [$serviceMock])->makePartial();
-        $controllerMock->shouldAllowMockingProtectedMethods();
-        $controllerMock->shouldReceive('rulesInsertTransfer')->once()->andReturn([]);
-
-        $response = $controllerMock->insertTransfer($this->getTransferRequest());
-
-        $this->assertEquals(500, $response->getStatusCode());
-        $this->assertEquals('Erro ao se conectar com o banco de dados!', $response->getData()->message);
     }
 
     public function testInsertTransferWithInvalidRequest()


### PR DESCRIPTION
Tratando exceptions que antes era tratado individualmente via try-catch em cada controller no handler do Laravel